### PR TITLE
Remove the "packageManager" field from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "0.1.0",
   "description": "",
   "main": "dist/index.js",
-  "packageManager": "pnpm@7.9.5",
   "scripts": {
     "lint": "eslint .",
     "test": "jest",


### PR DESCRIPTION
Removing since we are not using Corepack at the moment.

References:

- https://nodejs.org/dist/latest-v18.x/docs/api/all.html#all_packages_packagemanager
- https://nodejs.org/dist/latest-v18.x/docs/api/corepack.html