### PR TITLE
Downgrade @types/node to v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "@types/jest": "^29.4.0",
-    "@types/node": "^18.11.18",
+    "@types/node": "~16.18.11",
     "@typescript-eslint/eslint-plugin": "^5.49.0",
     "@typescript-eslint/parser": "^5.49.0",
     "@vercel/ncc": "^0.36.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,7 +8,7 @@ specifiers:
   '@actions/http-client': ^2.0.1
   '@actions/tool-cache': ^2.0.1
   '@types/jest': ^29.4.0
-  '@types/node': ^18.11.18
+  '@types/node': ~16.18.11
   '@typescript-eslint/eslint-plugin': ^5.49.0
   '@typescript-eslint/parser': ^5.49.0
   '@vercel/ncc': ^0.36.1
@@ -33,7 +33,7 @@ dependencies:
 
 devDependencies:
   '@types/jest': 29.4.0
-  '@types/node': 18.11.18
+  '@types/node': 16.18.11
   '@typescript-eslint/eslint-plugin': 5.49.0_iu322prlnwsygkcra5kbpy22si
   '@typescript-eslint/parser': 5.49.0_7uibuqfxkfaozanbtbziikiqje
   '@vercel/ncc': 0.36.1
@@ -42,7 +42,7 @@ devDependencies:
   eslint-config-airbnb-typescript: 17.0.0_zvmt5xh6vil4vpagx2utjxrocy
   eslint-plugin-import: 2.27.5_6savw6y3b7jng6f64kgkyoij64
   eslint-plugin-jest: 27.2.1_wl3grtzdhpdbdokams7wq4d444
-  jest: 29.4.1_@types+node@18.11.18
+  jest: 29.4.1_@types+node@16.18.11
   ts-jest: 29.0.5_xnqx6kewz4og5i3pgc6ahzwloy
   typescript: 4.9.4
 
@@ -972,6 +972,10 @@ packages:
       form-data: 3.0.1
     dev: false
 
+  /@types/node/16.18.11:
+    resolution: {integrity: sha512-3oJbGBUWuS6ahSnEq1eN2XrCyf4YsWI8OyCvo7c64zQJNplk3mO84t53o8lfTk+2ji59g5ycfc6qQ3fdHliHuA==}
+    dev: true
+
   /@types/node/18.11.18:
     resolution: {integrity: sha512-DHQpWGjyQKSHj3ebjFI/wRKcqQcdR+MoFBygntYOZytCqNfkd2ZC4ARDJ2DQqhjH5p85Nnd3jhUJIXrszFX/JA==}
 
@@ -1833,7 +1837,7 @@ packages:
       '@typescript-eslint/eslint-plugin': 5.49.0_iu322prlnwsygkcra5kbpy22si
       '@typescript-eslint/utils': 5.49.0_7uibuqfxkfaozanbtbziikiqje
       eslint: 8.32.0
-      jest: 29.4.1_@types+node@18.11.18
+      jest: 29.4.1_@types+node@16.18.11
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -2604,7 +2608,7 @@ packages:
       - supports-color
     dev: true
 
-  /jest-cli/29.4.1_@types+node@18.11.18:
+  /jest-cli/29.4.1_@types+node@16.18.11:
     resolution: {integrity: sha512-jz7GDIhtxQ37M+9dlbv5K+/FVcIo1O/b1sX3cJgzlQUf/3VG25nvuWzlDC4F1FLLzUThJeWLu8I7JF9eWpuURQ==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2621,7 +2625,7 @@ packages:
       exit: 0.1.2
       graceful-fs: 4.2.10
       import-local: 3.1.0
-      jest-config: 29.4.1_@types+node@18.11.18
+      jest-config: 29.4.1_@types+node@16.18.11
       jest-util: 29.4.1
       jest-validate: 29.4.1
       prompts: 2.4.2
@@ -2630,6 +2634,45 @@ packages:
       - '@types/node'
       - supports-color
       - ts-node
+    dev: true
+
+  /jest-config/29.4.1_@types+node@16.18.11:
+    resolution: {integrity: sha512-g7p3q4NuXiM4hrS4XFATTkd+2z0Ml2RhFmFPM8c3WyKwVDNszbl4E7cV7WIx1YZeqqCtqbtTtZhGZWJlJqngzg==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+    peerDependencies:
+      '@types/node': '*'
+      ts-node: '>=9.0.0'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      ts-node:
+        optional: true
+    dependencies:
+      '@babel/core': 7.20.12
+      '@jest/test-sequencer': 29.4.1
+      '@jest/types': 29.4.1
+      '@types/node': 16.18.11
+      babel-jest: 29.4.1_@babel+core@7.20.12
+      chalk: 4.1.2
+      ci-info: 3.7.1
+      deepmerge: 4.2.2
+      glob: 7.2.3
+      graceful-fs: 4.2.10
+      jest-circus: 29.4.1
+      jest-environment-node: 29.4.1
+      jest-get-type: 29.2.0
+      jest-regex-util: 29.2.0
+      jest-resolve: 29.4.1
+      jest-runner: 29.4.1
+      jest-util: 29.4.1
+      jest-validate: 29.4.1
+      micromatch: 4.0.5
+      parse-json: 5.2.0
+      pretty-format: 29.4.1
+      slash: 3.0.0
+      strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
 
   /jest-config/29.4.1_@types+node@18.11.18:
@@ -2959,7 +3002,7 @@ packages:
       supports-color: 8.1.1
     dev: true
 
-  /jest/29.4.1_@types+node@18.11.18:
+  /jest/29.4.1_@types+node@16.18.11:
     resolution: {integrity: sha512-cknimw7gAXPDOmj0QqztlxVtBVCw2lYY9CeIE5N6kD+kET1H4H79HSNISJmijb1HF+qk+G+ploJgiDi5k/fRlg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
@@ -2972,7 +3015,7 @@ packages:
       '@jest/core': 29.4.1
       '@jest/types': 29.4.1
       import-local: 3.1.0
-      jest-cli: 29.4.1_@types+node@18.11.18
+      jest-cli: 29.4.1_@types+node@16.18.11
     transitivePeerDependencies:
       - '@types/node'
       - supports-color
@@ -3733,7 +3776,7 @@ packages:
     dependencies:
       bs-logger: 0.2.6
       fast-json-stable-stringify: 2.1.0
-      jest: 29.4.1_@types+node@18.11.18
+      jest: 29.4.1_@types+node@16.18.11
       jest-util: 29.4.1
       json5: 2.2.3
       lodash.memoize: 4.1.2


### PR DESCRIPTION
Node.js 18 is not yet supported for a JavaScript action.

References:

- https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs
- https://json.schemastore.org/github-action.json